### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,9 @@ jobs:
 
 
   Lint:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ macos-latest, ubuntu-latest ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       - uses: actions/checkout@v4
@@ -32,10 +30,11 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - run: ./gradlew ciLint --stacktrace
+      - run: ./gradlew ktlintFormat ciLint --stacktrace
 
-      - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v2
+      - run: ./gradlew wrapper --gradle-version latest --stacktrace
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
 
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
Update CI workflow to:
- Run lint on ubuntu-latest instead of macos-latest and ubuntu-latest.
- Give write permissions to the workflow.
- Format code using ktlint before running lint.
- Update Gradle wrapper to the latest version.
- Auto commit changes made by the workflow.