### PR TITLE
Refactor: Update Koin KSP usage

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,7 +1,5 @@
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
@@ -14,28 +12,11 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(libs.versions.build.jvmTarget.get().toInt())
+
     androidTarget {
-        compilations.all {
-            compileTaskProvider {
-                compilerOptions {
-                    jvmTarget.set(JvmTarget.fromTarget(libs.versions.build.jvmTarget.get()))
-                    freeCompilerArgs.add(
-                        "-Xjdk-release=${
-                            JavaVersion.valueOf(libs.versions.build.javaVersion.get())
-                        }"
-                    )
-                }
-            }
-        }
         // https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
-        instrumentedTestVariant {
-            sourceSetTree.set(KotlinSourceSetTree.test)
-            dependencies {
-                debugImplementation(libs.androidx.compose.test.manifest)
-                implementation(libs.androidx.compose.test.junit4)
-            }
-        }
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
     }
 
     jvm()
@@ -44,11 +25,6 @@ kotlin {
         browser()
         binaries.executable()
     }
-
-//    wasmJs {
-//        browser()
-//        binaries.executable()
-//    }
 
     listOf(
         iosX64(),
@@ -151,8 +127,18 @@ compose.desktop {
 }
 
 dependencies {
-    ksp(libs.koin.ksp.compiler)
+    // KSP Tasks
+    add("kspAndroid", libs.koin.ksp.compiler)
+    add("kspCommonMainMetadata", libs.koin.ksp.compiler)
+    add("kspIosArm64", libs.koin.ksp.compiler)
+    add("kspIosSimulatorArm64", libs.koin.ksp.compiler)
+    add("kspIosX64", libs.koin.ksp.compiler)
+    add("kspJs", libs.koin.ksp.compiler)
+    add("kspJvm", libs.koin.ksp.compiler)
     debugImplementation(libs.leakcanary.android)
+    // https://developer.android.com/develop/ui/compose/testing#setup
+    debugImplementation(libs.androidx.compose.test.manifest)
+    implementation(libs.androidx.compose.test.junit4)
 }
 
 ksp {

--- a/convention-plugin-multiplatform/build.gradle.kts
+++ b/convention-plugin-multiplatform/build.gradle.kts
@@ -4,9 +4,11 @@ plugins {
 
 dependencies {
     compileOnly(libs.android.gradle.plugin)
+    compileOnly(libs.google.ksp.plugin)
     compileOnly(libs.jetbrains.compose.plugin)
     compileOnly(libs.kotlin.gradle.plugin)
     runtimeOnly(libs.android.gradle.plugin)
+    runtimeOnly(libs.google.ksp.plugin)
     runtimeOnly(libs.jetbrains.compose.compiler.plugin)
     runtimeOnly(libs.jetbrains.compose.plugin)
     runtimeOnly(libs.kotlin.gradle.plugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ androidx-compose-test-manifest = { module = "androidx.compose.ui:ui-test-manifes
 androidx-monitor = { group = "androidx.test", name = "monitor", version.ref = "androidx-monitor" }
 androidx-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidx-splashscreen" }
 gitlive-firebase-auth = { module = "dev.gitlive:firebase-auth", version.ref = "gitlive-firebase" }
+google-ksp-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "google-ksp" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 javax-json-api = { module = "javax.json:javax.json-api", version.ref = "javax-json" }
 javax-json-glassfish = { module = "org.glassfish:javax.json", version.ref = "javax-json" }

--- a/sharedCore/coreCommon/build.gradle.kts
+++ b/sharedCore/coreCommon/build.gradle.kts
@@ -1,18 +1,9 @@
 plugins {
     id("kotlinMultiplatformConvention")
     id("testOptionsConvention")
-    alias(libs.plugins.google.ksp)
 }
 
 android {
     namespace = "siarhei.luskanau.doorbell.mp.core.common"
     testOptions.configureTestOptions()
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/sharedCore/coreFirebase/build.gradle.kts
+++ b/sharedCore/coreFirebase/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("kotlinMultiplatformConvention")
     id("testOptionsConvention")
     alias(libs.plugins.buildConfig)
-    alias(libs.plugins.google.ksp)
 }
 
 kotlin {
@@ -18,14 +17,6 @@ kotlin {
 android {
     namespace = "siarhei.luskanau.doorbell.mp.core.firebase"
     testOptions.configureTestOptions()
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }
 
 buildConfig {

--- a/sharedUi/uiAuth/build.gradle.kts
+++ b/sharedUi/uiAuth/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("kotlinMultiplatformConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
-    alias(libs.plugins.google.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 kotlin {
@@ -20,12 +19,4 @@ android {
     namespace = "siarhei.luskanau.doorbell.mp.ui.auth"
     testOptions.configureTestOptions()
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/sharedUi/uiCommon/build.gradle.kts
+++ b/sharedUi/uiCommon/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
 }
+
 kotlin {
     sourceSets {
         commonMain.dependencies {

--- a/sharedUi/uiPermissions/build.gradle.kts
+++ b/sharedUi/uiPermissions/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("kotlinMultiplatformConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
-    alias(libs.plugins.google.ksp)
 }
 
 kotlin {
@@ -23,12 +22,4 @@ android {
     namespace = "siarhei.luskanau.doorbell.mp.ui.permissions"
     testOptions.configureTestOptions()
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/sharedUi/uiSplash/build.gradle.kts
+++ b/sharedUi/uiSplash/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("kotlinMultiplatformConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
-    alias(libs.plugins.google.ksp)
 }
 
 kotlin {
@@ -17,12 +16,4 @@ android {
     namespace = "siarhei.luskanau.doorbell.mp.ui.splash"
     testOptions.configureTestOptions()
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
-}
-
-dependencies {
-    ksp(libs.koin.ksp.compiler)
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }


### PR DESCRIPTION
Update Koin KSP usage to generate common metadata and apply it to all platforms.

This commit refactors the Koin KSP setup to improve build performance and ensure that the generated code is available for all platforms.

The following changes were made:

- Generate common metadata using KSP for all platforms.
- Trigger common metadata generation from Native tasks to ensure it's available during compilation.
- Use jvmToolchain for JVM target consistency.
- Update Gradle configurations to support KSP metadata generation.

This refactor improves build performance and ensures that the Koin generated code is available to all platforms during compilation.