### PR TITLE
Refactor: Create new KSP convention plugin

### DIFF
--- a/convention-plugin-multiplatform/src/main/kotlin/kotlinMultiplatformConvention.gradle.kts
+++ b/convention-plugin-multiplatform/src/main/kotlin/kotlinMultiplatformConvention.gradle.kts
@@ -7,7 +7,6 @@ val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs"
 plugins {
     id("com.android.library")
     id("org.jetbrains.compose")
-    id("com.google.devtools.ksp")
     kotlin("multiplatform")
     kotlin("plugin.compose")
 }
@@ -49,7 +48,6 @@ kotlin {
             implementation(compose.runtime)
             implementation(libs.findLibrary("jetbrains-lifecycle-viewmodel-compose").get())
             implementation(libs.findLibrary("jetbrains-navigation-compose").get())
-            implementation(libs.findLibrary("koin-annotations").get())
             implementation(libs.findLibrary("koin-core").get())
             implementation(libs.findLibrary("kotlinx-coroutines-core").get())
         }
@@ -94,19 +92,4 @@ android {
         )
     }
     packaging.resources.excludes.add("META-INF/**")
-}
-
-dependencies {
-    // KSP Tasks
-    add("kspAndroid", libs.findLibrary("koin-ksp-compiler").get())
-    add("kspCommonMainMetadata", libs.findLibrary("koin-ksp-compiler").get())
-    add("kspIosArm64", libs.findLibrary("koin-ksp-compiler").get())
-    add("kspIosSimulatorArm64", libs.findLibrary("koin-ksp-compiler").get())
-    add("kspIosX64", libs.findLibrary("koin-ksp-compiler").get())
-    add("kspJs", libs.findLibrary("koin-ksp-compiler").get())
-    add("kspJvm", libs.findLibrary("koin-ksp-compiler").get())
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK", "true")
 }

--- a/convention-plugin-multiplatform/src/main/kotlin/kotlinMultiplatformKspConvention.gradle.kts
+++ b/convention-plugin-multiplatform/src/main/kotlin/kotlinMultiplatformKspConvention.gradle.kts
@@ -1,0 +1,29 @@
+val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+plugins {
+    id("kotlinMultiplatformConvention")
+    id("com.google.devtools.ksp")
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.findLibrary("koin-annotations").get())
+        }
+    }
+}
+
+dependencies {
+    // KSP Tasks
+    add("kspAndroid", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspCommonMainMetadata", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspIosArm64", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspIosSimulatorArm64", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspIosX64", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspJs", libs.findLibrary("koin-ksp-compiler").get())
+    add("kspJvm", libs.findLibrary("koin-ksp-compiler").get())
+}
+
+ksp {
+    arg("KOIN_CONFIG_CHECK", "true")
+}

--- a/sharedCore/coreCommon/build.gradle.kts
+++ b/sharedCore/coreCommon/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("kotlinMultiplatformConvention")
+    id("kotlinMultiplatformKspConvention")
     id("testOptionsConvention")
 }
 

--- a/sharedCore/coreFirebase/build.gradle.kts
+++ b/sharedCore/coreFirebase/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("gsParserConvention")
-    id("kotlinMultiplatformConvention")
+    id("kotlinMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.buildConfig)
 }

--- a/sharedUi/uiAuth/build.gradle.kts
+++ b/sharedUi/uiAuth/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("kotlinMultiplatformConvention")
+    id("kotlinMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
     alias(libs.plugins.kotlinx.serialization)

--- a/sharedUi/uiPermissions/build.gradle.kts
+++ b/sharedUi/uiPermissions/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("kotlinMultiplatformConvention")
+    id("kotlinMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
 }

--- a/sharedUi/uiSplash/build.gradle.kts
+++ b/sharedUi/uiSplash/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("kotlinMultiplatformConvention")
+    id("kotlinMultiplatformKspConvention")
     id("testOptionsConvention")
     alias(libs.plugins.compose.screenshot)
 }


### PR DESCRIPTION
Created a new KSP convention plugin to handle KSP dependencies and arguments. Moved KSP dependencies and arguments from `kotlinMultiplatformConvention` to `kotlinMultiplatformKspConvention`. Updated modules to use the new `kotlinMultiplatformKspConvention` plugin.